### PR TITLE
Namespace package

### DIFF
--- a/src/java/com/vanillaforums/vanilla/jsConnect.java
+++ b/src/java/com/vanillaforums/vanilla/jsConnect.java
@@ -1,4 +1,4 @@
-package Vanilla;
+package com.vanillaforums.vanilla;
 
 import java.util.*;
 


### PR DESCRIPTION
Having a globally named package at `Vanilla` causes problems with build tools that expect things to live in namespaces, this fixes that.
